### PR TITLE
revert(rook): restore 1.19.6

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.2
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.2
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph-cluster


### PR DESCRIPTION
Reverts the Rook chart update from #581. Rook 1.20 cannot be reconciled safely as an in-place unattended upgrade, so restore both OCIRepository sources to v1.19.6.